### PR TITLE
POC: support external classes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 [[package]]
 name = "lean-sys"
 version = "0.0.3"
-source = "git+https://github.com/digama0/lean-sys.git#5b76a9a4c2f85c18f5ec065c0441f8afb1a6cfe3"
+source = "git+https://github.com/digama0/lean-sys.git#aacaf0b3db9e774388c38a088b0c84f4e154f8ad"
 dependencies = [
  "libc",
  "memoffset",
@@ -112,15 +112,15 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "static_assertions"
@@ -130,9 +130,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "d1eeca1c172a285ee6c2c84c341ccea837e7c01b12fbb2d0fe3c9e550ce49ec8"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -145,42 +145,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "b10d0c968ba7f6166195e13d593af609ec2e3d24f916f081690695cf5eaffb2f"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "571d8d4e62f26d4932099a9efe89660e8bd5087775a2ab5cdd8b747b811f1058"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "2229ad223e178db5fbbc8bd8d3835e51e566b8474bfca58d2e6150c48bb723cd"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "600956e2d840c194eedfc5d18f8242bc2e17c7775b6684488af3a9fff6fe3287"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "ea99ff3f8b49fb7a8e0d305e5aec485bd068c2ba691b6e277d29eaeac945868a"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "8f1a05a1ece9a7a0d5a7ccf30ba2c33e3a61a30e042ffd247567d1de1d94120d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "d419259aba16b663966e29e6d7c6ecfa0bb8425818bb96f6f1f3c3eb71a6e7b9"

--- a/base/src/external.rs
+++ b/base/src/external.rs
@@ -1,0 +1,109 @@
+use std::{ffi::c_void, ops::Deref};
+
+use lean_sys::{
+    lean_alloc_external, lean_apply_1, lean_external_class, lean_get_external_class,
+    lean_get_external_data, lean_inc, lean_is_exclusive, lean_object,
+};
+
+use crate::{Layout, Obj, ObjRef, TObj};
+
+// TODO: move this to lean_sys
+
+type LeanExternalForeachProc =
+    Option<unsafe extern "C" fn(data: *mut c_void, closure: *mut lean_object)>;
+type LeanExternalFinalizeProc = Option<unsafe extern "C" fn(data: *mut c_void)>;
+
+extern "C" {
+    fn lean_register_external_class(
+        finalize: LeanExternalFinalizeProc,
+        foreach: LeanExternalForeachProc,
+    ) -> *mut lean_external_class;
+}
+
+pub trait AsExternalObj: Clone + 'static {
+    type ObjIter<'a>: Iterator<Item = ObjRef<'a>>;
+    fn obj_iter(&self) -> Self::ObjIter<'_>;
+
+    unsafe extern "C" fn foreach(data: *mut c_void, closure: *mut lean_object) {
+        let data = data as *mut Self;
+        for i in (*data).obj_iter() {
+            lean_inc(i.0);
+            lean_inc(closure);
+            lean_apply_1(closure, i.0);
+        }
+    }
+
+    unsafe extern "C" fn finalize(data: *mut c_void) {
+        let data = data as *mut Self;
+        drop(Box::from_raw(data));
+    }
+
+    fn register() -> ExternalClass<Self> {
+        let class =
+            unsafe { lean_register_external_class(Some(Self::finalize), Some(Self::foreach)) };
+        ExternalClass {
+            class,
+            _type: std::marker::PhantomData,
+        }
+    }
+}
+
+#[repr(transparent)]
+pub struct ExternalClass<T: AsExternalObj> {
+    class: *mut lean_external_class,
+    _type: std::marker::PhantomData<T>,
+}
+
+impl<T: AsExternalObj> ExternalClass<T> {
+    pub fn class(&self) -> *mut lean_external_class {
+        self.class
+    }
+    pub fn create(&self, data: T) -> TObj<External<T>> {
+        let data = Box::new(data);
+        let data = Box::into_raw(data);
+        let external = External {
+            class: self.class,
+            data,
+        };
+        unsafe { TObj::new(External::pack_obj(external)) }
+    }
+}
+
+pub struct External<T: AsExternalObj> {
+    class: *mut lean_external_class,
+    data: *mut T,
+}
+
+impl<T: AsExternalObj> Layout for External<T> {
+    unsafe fn pack_obj(value: Self) -> Obj {
+        unsafe { Obj(lean_alloc_external(value.class, value.data as *mut c_void)) }
+    }
+
+    unsafe fn unpack_obj(value: Obj) -> Self {
+        let class = lean_get_external_class(value.0);
+        let data = lean_get_external_data(value.0) as *mut T;
+        Self { class, data }
+    }
+}
+
+impl<T: AsExternalObj> Deref for TObj<External<T>> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*(lean_get_external_data(self.obj.0) as *mut T) }
+    }
+}
+
+impl<T: AsExternalObj> TObj<External<T>> {
+    pub fn mutate<F: for<'a> FnOnce(&'a mut T)>(self, class: &ExternalClass<T>, f: F) -> Self {
+        unsafe {
+            if lean_is_exclusive(self.obj.0) {
+                f(&mut *(lean_get_external_data(self.obj.0) as *mut T));
+                self
+            } else {
+                let cloned = class.create((*self).clone());
+                f(&mut *(lean_get_external_data(cloned.obj.0) as *mut T));
+                cloned
+            }
+        }
+    }
+}

--- a/base/src/external.rs
+++ b/base/src/external.rs
@@ -5,7 +5,7 @@ use lean_sys::{
     lean_get_external_data, lean_inc, lean_is_exclusive, lean_object,
 };
 
-use crate::{Layout, Obj, ObjRef, TObj, TObjRef};
+use crate::{Layout, Obj, TObj, TObjRef};
 
 // TODO: move this to lean_sys
 
@@ -21,7 +21,7 @@ extern "C" {
 }
 
 pub trait AsExternalObj: Clone + 'static {
-    type ObjIter<'a>: Iterator<Item = ObjRef<'a>>;
+    type ObjIter<'a>: Iterator<Item = &'a Obj>;
     fn obj_iter(&self) -> Self::ObjIter<'_>;
 
     unsafe extern "C" fn foreach(data: *mut c_void, closure: *mut lean_object) {
@@ -96,7 +96,7 @@ impl<T: AsExternalObj> Deref for TObj<External<T>> {
 impl<T: AsExternalObj> Deref for TObjRef<'_, External<T>> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        unsafe { &*(lean_get_external_data(self.obj_ref.0) as *mut T) }
+        unsafe { &*(lean_get_external_data(self.obj) as *mut T) }
     }
 }
 

--- a/base/src/external.rs
+++ b/base/src/external.rs
@@ -2,23 +2,10 @@ use std::{ffi::c_void, ops::Deref};
 
 use lean_sys::{
     lean_alloc_external, lean_apply_1, lean_external_class, lean_get_external_class,
-    lean_get_external_data, lean_inc, lean_is_exclusive, lean_object,
+    lean_get_external_data, lean_inc, lean_is_exclusive, lean_object, lean_register_external_class,
 };
 
 use crate::{Layout, Obj, TObj, TObjRef};
-
-// TODO: move this to lean_sys
-
-type LeanExternalForeachProc =
-    Option<unsafe extern "C" fn(data: *mut c_void, closure: *mut lean_object)>;
-type LeanExternalFinalizeProc = Option<unsafe extern "C" fn(data: *mut c_void)>;
-
-extern "C" {
-    fn lean_register_external_class(
-        finalize: LeanExternalFinalizeProc,
-        foreach: LeanExternalForeachProc,
-    ) -> *mut lean_external_class;
-}
 
 pub trait AsExternalObj: Clone + 'static {
     type ObjIter<'a>: Iterator<Item = &'a Obj>;

--- a/base/src/external.rs
+++ b/base/src/external.rs
@@ -88,16 +88,10 @@ impl<T: AsExternalObj> Deref for TObjRef<'_, External<T>> {
 }
 
 impl<T: AsExternalObj> TObj<External<T>> {
-    pub fn mutate<F: for<'a> FnOnce(&'a mut T)>(self, class: &ExternalClass<T>, f: F) -> Self {
-        unsafe {
-            if lean_is_exclusive(self.obj.0) {
-                f(&mut *(lean_get_external_data(self.obj.0) as *mut T));
-                self
-            } else {
-                let cloned = class.create((*self).clone());
-                f(&mut *(lean_get_external_data(cloned.obj.0) as *mut T));
-                cloned
-            }
+    pub fn make_mut(&mut self, class: &ExternalClass<T>) -> &mut T {
+        if !unsafe { lean_is_exclusive(self.obj.0) } {
+            *self = class.create((**self).clone());
         }
+        unsafe { &mut *(lean_get_external_data(self.obj.0) as *mut T) }
     }
 }

--- a/base/src/external.rs
+++ b/base/src/external.rs
@@ -1,51 +1,98 @@
 use std::{ffi::c_void, ops::Deref};
 
 use lean_sys::{
-    lean_alloc_external, lean_apply_1, lean_external_class, lean_get_external_class,
-    lean_get_external_data, lean_inc, lean_is_exclusive, lean_object,
+    lean_alloc_external, lean_apply_1, lean_external_class, lean_get_external_data,
+    lean_is_exclusive, lean_register_external_class,
 };
 
-use crate::{Layout, Obj, TObj, TObjRef};
+use crate::{Layout, Obj, ObjPtr, TObj, TObjRef};
 
-pub unsafe trait Iterable {
-    fn foreach<F: Fn(&Obj)>(&self, _f: F) {}
+pub unsafe trait ForeachObj {
+    fn foreach_obj<F: Fn(Obj)>(&self, _f: &F) {}
 }
 
-pub unsafe trait AsExternalObj: Iterable + Clone + 'static {
-    const CLASS: lean_external_class = lean_external_class {
-        m_foreach: Some(foreach::<Self>),
-        m_finalize: Some(finalize::<Self>),
+unsafe impl ForeachObj for Obj {
+    fn foreach_obj<F: Fn(Obj)>(&self, f: &F) {
+        f(self.clone())
+    }
+}
+unsafe impl<A: ?Sized> ForeachObj for TObj<A> {
+    fn foreach_obj<F: Fn(Obj)>(&self, f: &F) {
+        self.obj.foreach_obj(f)
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct ExternalClass<T: ?Sized> {
+    class: lean_external_class,
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: ForeachObj> Default for ExternalClass<T> {
+    fn default() -> Self {
+        Self::CLASS
+    }
+}
+
+impl<T: ForeachObj> ExternalClass<T> {
+    pub const CLASS: Self = {
+        unsafe extern "C" fn foreach<T: ForeachObj>(data: *mut c_void, closure: ObjPtr) {
+            let data = data as *mut T;
+            let f = TObjRef::<fn(Obj)>::from_raw(closure);
+            (*data).foreach_obj(&move |obj| {
+                lean_apply_1(f.to_owned().into_raw(), obj.into_raw());
+            })
+        }
+
+        unsafe extern "C" fn finalize<T>(data: *mut c_void) {
+            let data = data as *mut T;
+            drop(Box::from_raw(data));
+        }
+
+        Self {
+            class: lean_external_class {
+                m_finalize: Some(finalize::<T>),
+                m_foreach: Some(foreach::<T>),
+            },
+            _phantom: std::marker::PhantomData,
+        }
     };
+
+    pub const fn raw(&self) -> *mut lean_external_class {
+        &self.class as *const _ as *mut _
+    }
+
+    pub fn register(self) -> &'static Self {
+        let class =
+            unsafe { lean_register_external_class(self.class.m_finalize, self.class.m_foreach) };
+        unsafe { &*(class as *mut Self) }
+    }
 }
 
-unsafe extern "C" fn foreach<T: Iterable>(data: *mut c_void, closure: *mut lean_object) {
-    let data = data as *mut T;
-    (*data).foreach(|obj| {
-        lean_inc(obj.0);
-        lean_inc(closure);
-        lean_apply_1(closure, obj.0);
-    });
-}
-
-unsafe extern "C" fn finalize<T>(data: *mut c_void) {
-    let data = data as *mut T;
-    drop(Box::from_raw(data));
-}
+pub trait AsExternalObj: ForeachObj + Sized + 'static {}
 
 pub struct External<T: AsExternalObj> {
-    class: *mut lean_external_class,
     data: *mut T,
+}
+
+impl<T: AsExternalObj> External<T> {
+    pub fn new(data: T) -> Self {
+        External {
+            data: Box::into_raw(Box::new(data)),
+        }
+    }
 }
 
 impl<T: AsExternalObj> Layout for External<T> {
     unsafe fn pack_obj(value: Self) -> Obj {
-        unsafe { Obj(lean_alloc_external(value.class, value.data as *mut c_void)) }
+        let cls = ExternalClass::<T>::CLASS.raw();
+        unsafe { Obj(lean_alloc_external(cls, value.data as *mut c_void)) }
     }
 
     unsafe fn unpack_obj(value: Obj) -> Self {
-        let class = lean_get_external_class(value.0);
         let data = lean_get_external_data(value.0) as *mut T;
-        Self { class, data }
+        Self { data }
     }
 }
 
@@ -65,15 +112,15 @@ impl<T: AsExternalObj> Deref for TObjRef<'_, External<T>> {
 
 impl<T: AsExternalObj> From<T> for TObj<External<T>> {
     fn from(value: T) -> Self {
-        let data = Box::into_raw(Box::new(value));
-        let class = &T::CLASS as *const _ as *mut _;
-        let external = External { data, class };
-        external.pack()
+        External::new(value).pack()
     }
 }
 
 impl<T: AsExternalObj> TObj<External<T>> {
-    pub fn make_mut(&mut self) -> &mut T {
+    pub fn make_mut(&mut self) -> &mut T
+    where
+        T: Clone,
+    {
         if !unsafe { lean_is_exclusive(self.obj.0) } {
             *self = (**self).clone().into();
         }

--- a/base/src/external.rs
+++ b/base/src/external.rs
@@ -5,7 +5,7 @@ use lean_sys::{
     lean_get_external_data, lean_inc, lean_is_exclusive, lean_object,
 };
 
-use crate::{Layout, Obj, ObjRef, TObj};
+use crate::{Layout, Obj, ObjRef, TObj, TObjRef};
 
 // TODO: move this to lean_sys
 
@@ -90,6 +90,13 @@ impl<T: AsExternalObj> Deref for TObj<External<T>> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         unsafe { &*(lean_get_external_data(self.obj.0) as *mut T) }
+    }
+}
+
+impl<T: AsExternalObj> Deref for TObjRef<'_, External<T>> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*(lean_get_external_data(self.obj_ref.0) as *mut T) }
     }
 }
 

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -1,19 +1,13 @@
 #![allow(clippy::missing_safety_doc)]
+
 pub mod external;
 pub mod typed;
-use std::marker::PhantomData;
-
 use lean_sys::*;
 pub use typed::*;
 
 pub type ObjPtr = *mut lean_object;
 #[repr(transparent)]
 pub struct Obj(pub ObjPtr);
-
-#[derive(Copy, Clone)]
-#[repr(transparent)]
-pub struct ObjRef<'a>(pub ObjPtr, PhantomData<&'a ()>);
-
 impl Drop for Obj {
     fn drop(&mut self) {
         unsafe { lean_dec(self.0) }
@@ -49,10 +43,6 @@ impl Obj {
         p
     }
 
-    pub fn as_ref(&self) -> ObjRef<'_> {
-        ObjRef(self.0, PhantomData)
-    }
-
     pub unsafe fn ctor<const N: usize, T>(tag: u8, args: [Obj; N], scalars: T) -> Obj {
         let o = Obj(lean_alloc_ctor(
             tag.into(),
@@ -74,15 +64,6 @@ impl Obj {
             &*lean_string_cstr(self.0),
             lean_string_size(self.0) - 1,
         ))
-    }
-}
-
-impl ObjRef<'_> {
-    pub fn to_owned(self) -> Obj {
-        unsafe {
-            lean_inc(self.0);
-            Obj(self.0)
-        }
     }
 }
 

--- a/base/src/typed.rs
+++ b/base/src/typed.rs
@@ -36,6 +36,12 @@ impl<A: ?Sized> Clone for TObj<A> {
 }
 
 impl<A: ?Sized> TObjRef<'_, A> {
+    pub const unsafe fn from_raw(obj: ObjPtr) -> Self {
+        Self {
+            obj,
+            val: PhantomData,
+        }
+    }
     pub fn to_owned(self) -> TObj<A> {
         unsafe {
             lean_inc(self.obj);

--- a/base/src/typed.rs
+++ b/base/src/typed.rs
@@ -1,4 +1,4 @@
-use core::{marker::PhantomData, ops::Deref};
+use std::{marker::PhantomData, ops::Deref};
 
 use super::*;
 
@@ -22,8 +22,8 @@ pub struct TObj<A: ?Sized> {
 #[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct TObjRef<'a, A: ?Sized> {
-    pub(crate) obj_ref: ObjRef<'a>,
-    val: PhantomData<A>,
+    pub(crate) obj: ObjPtr,
+    val: PhantomData<&'a A>,
 }
 
 impl<A: ?Sized> Clone for TObj<A> {
@@ -37,7 +37,10 @@ impl<A: ?Sized> Clone for TObj<A> {
 
 impl<A: ?Sized> TObjRef<'_, A> {
     pub fn to_owned(self) -> TObj<A> {
-        unsafe { TObj::from_obj(self.obj_ref.to_owned()) }
+        unsafe {
+            lean_inc(self.obj);
+            TObj::from_raw(self.obj)
+        }
     }
 }
 
@@ -50,9 +53,6 @@ impl<A: ?Sized> TObj<A> {
     }
     pub const unsafe fn from_raw(obj: ObjPtr) -> Self {
         Self::new(Obj(obj))
-    }
-    pub const unsafe fn from_obj(obj: Obj) -> Self {
-        Self::new(obj)
     }
     pub fn into_obj(self) -> Obj {
         self.obj
@@ -68,7 +68,7 @@ impl<A: ?Sized> TObj<A> {
     }
     pub fn as_ref(&self) -> TObjRef<'_, A> {
         TObjRef {
-            obj_ref: self.obj.as_ref(),
+            obj: self.obj.0,
             val: PhantomData,
         }
     }

--- a/base/src/typed.rs
+++ b/base/src/typed.rs
@@ -22,7 +22,7 @@ pub struct TObj<A: ?Sized> {
 #[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct TObjRef<'a, A: ?Sized> {
-    obj_ref: ObjRef<'a>,
+    pub(crate) obj_ref: ObjRef<'a>,
     val: PhantomData<A>,
 }
 


### PR DESCRIPTION
This provides a way to directly wrap rust objects as `lean_external_object`s.

BTW, I also noticed that there is yet another crate https://github.com/LemonHX/lean4-rs/tree/master by @LemonHX providing high-level wrappers. It is of good quality but it lacks the abstraction of reference and does not give as many as type-aware conversions planned in this repo. 

Speaking of which, I think the macro in  @LemonHX's repo looks promising. We can also provide something similar.

One may feel curious about the bound: `AsExternalObject : Clone + 'static`. This is required for soundness. For instance,
users should not store short-life/dangling references in their data structure, wrapping it as an `ExternalObject` and passing them back to `lean`.
